### PR TITLE
fix: explicitly fetch 'master' branch from torvalds tree so FETCH_HEAD is not confused

### DIFF
--- a/work_kernel_tree.sh
+++ b/work_kernel_tree.sh
@@ -72,7 +72,7 @@ if ! git config "remote.${GIT_TORVALDS_BUNDLE_REMOTE_NAME}.url"; then
 	display_alert "Fetching from cold git bundle, wait" "${GIT_TORVALDS_BUNDLE_ID}"
 	git bundle verify "${GIT_TORVALDS_BUNDLE_FILE}"                                   # Make sure bundle is valid.
 	git remote add "${GIT_TORVALDS_BUNDLE_REMOTE_NAME}" "${GIT_TORVALDS_BUNDLE_FILE}" # Add the remote pointing to the cold bundle file
-	git fetch --progress --verbose "${GIT_TORVALDS_BUNDLE_REMOTE_NAME}"               # Fetch it!
+	git fetch --progress --verbose "${GIT_TORVALDS_BUNDLE_REMOTE_NAME}" master        # Fetch it!
 else
 	display_alert "Torvalds bundle already fetched..."
 fi


### PR DESCRIPTION
> tl-dr: Torvalds pushed a `arm64-uaccess` branch besides his `master` branch, things broke.

#### fix: explicitly fetch 'master' branch from torvalds tree so FETCH_HEAD is not confused

- fixes exporting 6.11
- previously, Torvalds _only_ had a 'master' branch
- he recently pushed a `arm64-uaccess` branch (oh, the irony)
  - thus `FETCH_HEAD` pointed to it, which didn't have master's 6.11 commits
  - thus shallowing out failed