### PR TITLE
ci: make git-trees workflow resilient to network failures

### DIFF
--- a/.github/workflows/maintenance-git-trees-oras.yml
+++ b/.github/workflows/maintenance-git-trees-oras.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Free Github Runner
-        uses: descriptinc/free-disk-space@main
+        uses: descriptinc/free-disk-space@main # no tagged releases; pinned to default branch
         with:
           android: true
           dotnet: true
@@ -24,16 +24,16 @@ jobs:
           large-packages: true
           docker-images: true
           swap-storage: true
-    
+
       - name: Docker Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }} # GitHub username or org
           password: ${{ secrets.GITHUB_TOKEN }}    # GitHub actions builtin token. repo has to have pkg access.
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Keep alive
         uses: liskin/gh-workflow-keepalive@v1
@@ -47,11 +47,14 @@ jobs:
           date > "${TARGET_FULL_FILE_PATH}"
           bash oras_upload.sh
 
-      - name: Cache git worktree
-        uses: actions/cache@v4
+      # Restore the most recent worktree cache. The key is unique per run so that the
+      # matching save step below always writes a fresh cache; restore-keys does a prefix
+      # match to pull in whatever the latest previous run produced.
+      - name: Restore git worktree cache
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/workdir/kernel/worktree
-          key: ${{ runner.os }}-kernel-worktree-${{ github.sha }}
+          key: ${{ runner.os }}-kernel-worktree-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             ${{ runner.os }}-kernel-worktree
 
@@ -59,12 +62,25 @@ jobs:
         run: |
           BASE_WORK_DIR="/tmp/workdir" bash work_kernel_tree.sh
 
+      # Save the worktree cache even when the bulk-of-work step above failed (it fails
+      # intermittently due to network issues). This lets the next run continue from the
+      # partial progress instead of starting over. Skipped only on cancellation.
+      - name: Save git worktree cache
+        if: ${{ !cancelled() }}
+        uses: actions/cache/save@v5
+        with:
+          path: /tmp/workdir/kernel/worktree
+          key: ${{ runner.os }}-kernel-worktree-${{ github.run_id }}-${{ github.run_attempt }}
+
+      # Publishing steps below have no explicit "if", so they keep the default success()
+      # condition: they only run when every previous step (including the bulk of work)
+      # succeeded. A failed bulk-of-work step therefore skips publishing but still saves cache.
       - name: Upload multiple shallow trees to ghcr.io via ORAS
         env:
           TARGET_OCI_PREFIX: "ghcr.io/${{ github.repository }}/kernel-git-shallow" # :latest
           OUTPUT_BASE: "/tmp/workdir/kernel/output_oras"
         run: |
-          for KERNEL_VERSION in $(cat ${OUTPUT_BASE}/shallow_versions.txt); do 
+          for KERNEL_VERSION in $(cat ${OUTPUT_BASE}/shallow_versions.txt); do
              echo "::group::Pushing ORAS bundle for shallow ${KERNEL_VERSION}"
              echo "version: $KERNEL_VERSION"
              export TARGET_OCI="${TARGET_OCI_PREFIX}-${KERNEL_VERSION}:latest"
@@ -81,4 +97,3 @@ jobs:
           TARGET_FULL_FILE_PATH: "/tmp/workdir/kernel/output_oras/linux-complete.git.tar"
         run: |
           bash oras_upload.sh
-

--- a/work_kernel_tree.sh
+++ b/work_kernel_tree.sh
@@ -5,9 +5,34 @@ set -e
 function display_alert() {
 	echo "--> $*"
 }
+
+# Retry a (remote) command up to RETRY_MAX_ATTEMPTS times, with an increasing delay
+# between attempts (RETRY_BASE_DELAY, doubling each time). Used to wrap network/git
+# operations against kernel.org, which fail intermittently. Returns the last exit code.
+RETRY_MAX_ATTEMPTS="${RETRY_MAX_ATTEMPTS:-5}"
+RETRY_BASE_DELAY="${RETRY_BASE_DELAY:-10}"
+function run_with_retries() {
+	local -i attempt=1
+	local -i delay="${RETRY_BASE_DELAY}"
+	local -i rc=0
+	while true; do
+		display_alert "Attempt ${attempt}/${RETRY_MAX_ATTEMPTS}:" "$*"
+		"$@" && return 0
+		rc=$?
+		if [[ ${attempt} -ge ${RETRY_MAX_ATTEMPTS} ]]; then
+			display_alert "Command failed after ${RETRY_MAX_ATTEMPTS} attempts (rc=${rc}):" "$*" "err"
+			return ${rc}
+		fi
+		display_alert "Command failed (rc=${rc}), retrying in ${delay}s:" "$*" "wrn"
+		sleep "${delay}"
+		attempt+=1
+		delay=$((delay * 2))
+	done
+}
+
 echo "::group::Read kernel.org versions"
 # Read the current versions of kernel from kernel.org JSON releases. Again, thanks, kernel.org.
-curl --silent "https://www.kernel.org/releases.json" > /tmp/kernel-releases.json
+run_with_retries curl --fail --silent --output /tmp/kernel-releases.json "https://www.kernel.org/releases.json"
 echo "Kernel releases versions from JSON:"
 cat /tmp/kernel-releases.json | jq -r ".releases[].version"
 
@@ -63,7 +88,7 @@ if ! git config "remote.${GIT_TORVALDS_BUNDLE_REMOTE_NAME}.url"; then
 	# Grab torvald's gitbundle via http from kernel.org
 	if [[ ! -f "${GIT_TORVALDS_BUNDLE_FILE}" ]]; then # Download the bundle file if it does not exist.
 		display_alert "Downloading Git cold bundle via HTTP" "${GIT_TORVALDS_BUNDLE_URL}"
-		wget --continue --progress=dot:giga --output-document="${GIT_TORVALDS_BUNDLE_FILE}" "${GIT_TORVALDS_BUNDLE_URL}"
+		run_with_retries wget --continue --progress=dot:giga --output-document="${GIT_TORVALDS_BUNDLE_FILE}" "${GIT_TORVALDS_BUNDLE_URL}"
 	else
 		display_alert "Cold bundle file exists, using it" "${GIT_TORVALDS_BUNDLE_FILE}" "git"
 	fi
@@ -94,7 +119,7 @@ fi
 # Fetch from it (to update), also bring in the tags. Around a 60mb download, quite fast.
 if [[ "${ONLINE}" == "yes" ]]; then
 	display_alert "Fetching from torvalds live" "${GIT_TORVALDS_LIVE_REMOTE_NAME}"
-	git fetch --progress --verbose --tags "${GIT_TORVALDS_LIVE_REMOTE_NAME}" master # Fetch it! (including tags!)
+	run_with_retries git fetch --progress --verbose --tags "${GIT_TORVALDS_LIVE_REMOTE_NAME}" master # Fetch it! (including tags!)
 	# create a local branch from the fetched
 	display_alert "Creating local branch 'torvalds-master' from torvalds live" "${GIT_TORVALDS_LIVE_REMOTE_NAME}"
 	git branch --force "torvalds-master" FETCH_HEAD
@@ -128,7 +153,7 @@ for KERNEL_VERSION in "${WANTED_KERNEL_VERSIONS[@]}"; do
 	# Fetch the branch from the stable live into the local branch. Since I don't specify "--tags", it will only fetch the tags for the branch. Those DON'T include the -rc tags which came from torvalds live
 	if [[ "${ONLINE}" == "yes" ]]; then
 		declare -i STABLE_EXISTS=0
-		git fetch --progress --verbose "${GIT_STABLE_LIVE_REMOTE_NAME}" "${KERNEL_VERSION_REMOTE_BRANCH_NAME}:${KERNEL_VERSION_LOCAL_BRANCH_NAME}" && STABLE_EXISTS=1
+		run_with_retries git fetch --progress --verbose "${GIT_STABLE_LIVE_REMOTE_NAME}" "${KERNEL_VERSION_REMOTE_BRANCH_NAME}:${KERNEL_VERSION_LOCAL_BRANCH_NAME}" && STABLE_EXISTS=1
 		if [[ ${STABLE_EXISTS} -eq 0 ]]; then
 			display_alert "Stable branch does not exist, copying torvalds-master to" "${KERNEL_VERSION_REMOTE_BRANCH_NAME}"
 			git branch --force "${KERNEL_VERSION_LOCAL_BRANCH_NAME}" "torvalds-master"


### PR DESCRIPTION
The bulk-of-work step fails intermittently due to network issues with kernel.org. Rework so partial progress is preserved and publishing only happens on full success:

- Split actions/cache into restore + save; save runs with if: !cancelled() right after the bulk-of-work step, so the worktree cache is written even when that step fails.
- Switch the cache key to github.run_id/run_attempt (unique per run) so every run saves a fresh cache; restore-keys prefix-matches the latest. The old github.sha key never re-saved across scheduled runs on the same commit, losing progress.
- ORAS publishing keeps the default success() condition, so it is skipped when the bulk-of-work step fails (cache still saved).
- Bump actions to latest stable: docker/login-action v3->v4, actions/checkout v4->v6, actions/cache v4->v5.

Add run_with_retries helper to work_kernel_tree.sh: up to 5 attempts with doubling delay. Wrap remote operations against kernel.org (curl of releases.json, wget of the cold bundle, git fetch of torvalds-live and stable remotes).